### PR TITLE
Add factoid command to the bot

### DIFF
--- a/src/main/java/uk/co/unitycoders/pircbotx/Bot.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/Bot.java
@@ -62,6 +62,7 @@ public class Bot {
         processor.register("profile", new ProfileCommand(profiles));
         processor.register("help", new HelpCommand(processor));
         processor.register("nick", new NickCommand());
+        processor.register("factoid", new FactoidCommand(DBConnection.getFactoidModel()));
 
         PircBotX bot = new PircBotX();
         ListenerManager<? extends PircBotX> manager = bot.getListenerManager();

--- a/src/main/java/uk/co/unitycoders/pircbotx/commands/FactoidCommand.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/commands/FactoidCommand.java
@@ -1,0 +1,81 @@
+package uk.co.unitycoders.pircbotx.commands;
+
+import uk.co.unitycoders.pircbotx.commandprocessor.Command;
+import uk.co.unitycoders.pircbotx.commandprocessor.Message;
+import uk.co.unitycoders.pircbotx.data.db.FactoidModel;
+
+import java.sql.SQLException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Created by webpigeon on 16/12/13.
+ */
+public class FactoidCommand {
+    private FactoidModel model;
+    private Pattern factoidPattern;
+
+    public FactoidCommand(FactoidModel model) {
+        this.model = model;
+        this.factoidPattern = Pattern.compile(".factoid ([^ ]+) (\\S+) (.+)");
+    }
+
+    @Command("add")
+    public void addFactoid(Message message) throws SQLException {
+        String messageText = message.getMessage();
+
+        Matcher matcher = factoidPattern.matcher(messageText);
+        if (!matcher.matches()) {
+            message.respond("usage: factoid add [name] [text]");
+        }
+
+        boolean status = model.addFactoid(matcher.group(2), matcher.group(3));
+
+        String result = status?"Factoid added successfully":"factoid failed to get added";
+        message.respond(result);
+    }
+
+    @Command("get")
+    public void getFactoid(Message message) throws SQLException {
+        String messageText = message.getMessage();
+        String[] args = messageText.split(" ");
+
+        if (args.length != 3) {
+            message.respond("usage: factoid get [name]");
+        }
+
+        String factoid = model.getFactoid(args[2]);
+        if (factoid == null) {
+            message.respond("Sorry, unknown factoid.");
+        } else {
+            message.respond(factoid);
+        }
+    }
+
+    @Command("edit")
+    public void updateFactoid(Message message) throws SQLException {
+        String messageText = message.getMessage();
+
+        Matcher matcher = factoidPattern.matcher(messageText);
+        if (!matcher.matches()) {
+            message.respond("usage: factoid add [name] [text]");
+        }
+
+        model.editFactoid(matcher.group(2), matcher.group(3));
+    }
+
+    @Command("remove")
+    public void removeFactoid(Message message) throws SQLException {
+        String messageText = message.getMessage();
+        String[] args = messageText.split(" ");
+
+        if (args.length != 3) {
+            message.respond("usage: factoid remove [name]");
+        }
+
+        boolean status = model.deleteFactoid(args[2]);
+        String result = status?"Factoid removed successfully":"factoid failed to get removed";
+        message.respond(result);
+    }
+
+}

--- a/src/main/java/uk/co/unitycoders/pircbotx/data/db/DBConnection.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/data/db/DBConnection.java
@@ -79,4 +79,8 @@ public class DBConnection {
     public static ProfileModel getProfileModel() throws ClassNotFoundException, SQLException {
         return new ProfileModel(getInstance());
     }
+
+    public static FactoidModel getFactoidModel() throws ClassNotFoundException, SQLException {
+        return new FactoidModel(getInstance());
+    }
 }

--- a/src/main/java/uk/co/unitycoders/pircbotx/data/db/FactoidModel.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/data/db/FactoidModel.java
@@ -1,0 +1,67 @@
+package uk.co.unitycoders.pircbotx.data.db;
+
+import uk.co.unitycoders.pircbotx.commandprocessor.Command;
+import uk.co.unitycoders.pircbotx.commandprocessor.Message;
+
+import java.sql.*;
+import java.util.regex.Pattern;
+
+/**
+ * Created by webpigeon on 16/12/13.
+ */
+public class FactoidModel {
+    private Connection connection;
+
+    private final PreparedStatement createStmt;
+    private final PreparedStatement readStmt;
+    private final PreparedStatement updateStmt;
+    private final PreparedStatement deleteStmt;
+
+    public FactoidModel(Connection connection) throws SQLException {
+        this.connection = connection;
+        buildTable();
+
+        createStmt = connection.prepareStatement("INSERT INTO factoid VALUES (?,?);");
+        readStmt = connection.prepareStatement("SELECT body FROM factoid WHERE name=?;");
+        updateStmt = connection.prepareStatement("UPDATE factoid SET body=? WHERE name=?");
+        deleteStmt = connection.prepareStatement("DELETE FROM factoid WHERE name=?");
+    }
+
+    private void buildTable() throws SQLException {
+        Statement stmt = connection.createStatement();
+        stmt.executeUpdate("CREATE TABLE IF NOT EXISTS factoid (name TEXT PRIMARY KEY, body TEXT)");
+    }
+
+    public boolean addFactoid(String factoid, String text) throws SQLException {
+        createStmt.clearParameters();
+        createStmt.setString(1, factoid);
+        createStmt.setString(2, text);
+        return createStmt.execute();
+    }
+
+    public String getFactoid(String factoid) throws SQLException {
+        readStmt.clearParameters();
+        readStmt.setString(1, factoid);
+
+        ResultSet rs = readStmt.executeQuery();
+        if (rs.next()) {
+            return rs.getString(1);
+        }
+
+        return null;
+    }
+
+    public boolean editFactoid(String factoid, String text) throws SQLException {
+        updateStmt.clearParameters();
+        updateStmt.setString(1, factoid);
+        updateStmt.setString(2, text);
+        return updateStmt.executeUpdate() == 1;
+    }
+
+    public boolean deleteFactoid(String factoid) throws SQLException {
+        deleteStmt.clearParameters();
+        deleteStmt.setString(1, factoid);
+        return deleteStmt.execute();
+    }
+
+}


### PR DESCRIPTION
This adds a factoid plugin to the IRC bot. This enables people to store simple messages associated with a key. The bot can then retrieve these messages on command.
