### PR TITLE
Feature backends

### DIFF
--- a/src/main/java/uk/co/unitycoders/pircbotx/BotRunnable.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/BotRunnable.java
@@ -29,8 +29,8 @@ import org.pircbotx.PircBotX;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import uk.co.unitycoders.pircbotx.backends.irc.IRCFactory;
 import uk.co.unitycoders.pircbotx.commandprocessor.CommandProcessor;
-import uk.co.unitycoders.pircbotx.commandprocessor.irc.IRCFactory;
 import uk.co.unitycoders.pircbotx.commands.HelpCommand;
 import uk.co.unitycoders.pircbotx.commands.PluginCommand;
 import uk.co.unitycoders.pircbotx.listeners.JoinsListener;

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/AbstractMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/AbstractMessage.java
@@ -1,0 +1,69 @@
+package uk.co.unitycoders.pircbotx.backends;
+
+import java.util.Iterator;
+import java.util.List;
+
+import uk.co.unitycoders.pircbotx.commandprocessor.Message;
+
+/**
+ * Things common to messages regardless of the backend.
+ */
+public abstract class AbstractMessage implements Message {
+	private final List<String> args;
+	
+	public AbstractMessage(List<String> args) {
+		this.args = args;
+	}
+
+	@Override
+	public String getMessage() {
+		if (args.size() <= 2) {
+			return "";
+		}
+
+		// get the argument list
+		List<String> cmdArgs = args.subList(2, args.size());
+
+		//emulate String.join in java 1.7
+		StringBuilder argStr = new StringBuilder();
+		Iterator<String> argItr = cmdArgs.iterator();
+		while(argItr.hasNext()) {
+			argStr.append(argItr.next());
+			if (argItr.hasNext()) {
+				argStr.append(" ");
+			}
+		}
+
+		return argStr.toString();
+	}
+
+	@Override
+	public  String getRawMessage() {
+		return getMessage();
+	}
+
+	@Override
+	public String getArgument(int id, String defaultValue) {
+		if (args == null || args.size() <= id){
+			return defaultValue;
+		}
+
+		return args.get(id);
+	}
+
+	@Override
+	public String getArgument(int id) {
+		return args.get(id);
+	}
+
+	@Override
+	public void insertArgument(int i, String arg) {
+		args.add(i, arg);	
+	}
+	
+	@Override
+	public void respondSuccess() {
+		respond("The operation was successful.");
+	}
+	
+}

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/console/InteractiveMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/console/InteractiveMessage.java
@@ -1,0 +1,46 @@
+package uk.co.unitycoders.pircbotx.backends.console;
+
+import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.List;
+
+import org.pircbotx.PircBotX;
+import org.pircbotx.User;
+
+import uk.co.unitycoders.pircbotx.backends.AbstractMessage;
+import uk.co.unitycoders.pircbotx.commandprocessor.Message;
+
+public class InteractiveMessage extends AbstractMessage {
+	private final PrintStream out;
+	
+	public InteractiveMessage(List<String> args, PrintStream out) {
+		super(args);
+		this.out = out;
+	}
+	
+	@Override
+	public PircBotX getBot() {
+		return null;
+	}
+
+	@Override
+	public User getUser() {
+		return null;
+	}
+
+	@Override
+	public String getTargetName() {
+		return "consoleUser";
+	}
+
+	@Override
+	public void respond(String message) {
+		out.println(String.format("bot: %s", message));
+	}
+
+	@Override
+	public void sendAction(String action) {
+		out.println(String.format("* %s *", action));
+	}
+
+}

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/console/InteractivePrompt.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/console/InteractivePrompt.java
@@ -1,0 +1,44 @@
+package uk.co.unitycoders.pircbotx.backends.console;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+
+import uk.co.unitycoders.pircbotx.commandprocessor.CommandProcessor;
+import uk.co.unitycoders.pircbotx.commandprocessor.Message;
+import uk.co.unitycoders.pircbotx.middleware.BotMiddleware;
+
+/**
+ * This emulates the bot as in interactive prompt on the terminal.
+ */
+public class InteractivePrompt {
+
+	public static void main(String[] args) {
+		List<BotMiddleware> middleware = Collections.emptyList();
+		CommandProcessor processor = new CommandProcessor(middleware);
+		
+		doPrompt(processor);
+	}
+	
+	private static void doPrompt(CommandProcessor processor) {
+		Scanner scanner = new Scanner(System.in);
+		System.out.println("Interactive Prompt");
+		System.out.println("the bot will evaluate any input in stdin as a command");
+		
+		while(scanner.hasNextLine()) {
+			try {
+				processor.invoke(buildMessage(processor, scanner.nextLine()));
+			} catch (Exception ex) {
+				System.err.println(String.format("[error] %s", ex));
+				ex.printStackTrace();
+			}
+		}
+		
+		scanner.close();
+	}
+	
+	private static Message buildMessage(CommandProcessor processor, String line) {
+		List<String> args = processor.processMessage(line);
+		return new InteractiveMessage(args, System.out);
+	}
+}

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/BasicMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/BasicMessage.java
@@ -18,7 +18,6 @@
  */
 package uk.co.unitycoders.pircbotx.backends.irc;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.pircbotx.PircBotX;
@@ -26,7 +25,6 @@ import org.pircbotx.User;
 import org.pircbotx.hooks.types.GenericMessageEvent;
 
 import uk.co.unitycoders.pircbotx.backends.AbstractMessage;
-import uk.co.unitycoders.pircbotx.commandprocessor.Message;
 
 /**
  * Abstract message adapter for uc_pircbotx.

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/BasicMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/BasicMessage.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * uc_pircbotx. If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.backends.irc;
 
 import java.util.Iterator;
 import java.util.List;
@@ -25,6 +25,7 @@ import org.pircbotx.PircBotX;
 import org.pircbotx.User;
 import org.pircbotx.hooks.types.GenericMessageEvent;
 
+import uk.co.unitycoders.pircbotx.backends.AbstractMessage;
 import uk.co.unitycoders.pircbotx.commandprocessor.Message;
 
 /**
@@ -33,81 +34,17 @@ import uk.co.unitycoders.pircbotx.commandprocessor.Message;
  * An abstract version of the Bot Message interface which deals with some of
  * the common features which we can deal with for the child classes.
  */
-abstract class BasicMessage implements Message {
+abstract class BasicMessage extends AbstractMessage {
 	private final GenericMessageEvent event;
-	private final List<String> args;
 
 	public BasicMessage(GenericMessageEvent message, List<String> args) {
+		super(args);
 		this.event = message;
-		this.args = args;
-	}
-
-	public String getArguments() {
-		if (args.size() <= 2) {
-			return "";
-		}
-
-		// get the argument list
-		List<String> cmdArgs = args.subList(2, args.size());
-
-		//emulate String.join in java 1.7
-		StringBuilder argStr = new StringBuilder();
-		Iterator<String> argItr = cmdArgs.iterator();
-		while(argItr.hasNext()) {
-			argStr.append(argItr.next());
-			if (argItr.hasNext()) {
-				argStr.append(" ");
-			}
-		}
-
-		return argStr.toString();
-	}
-
-	public int getArgumentCount() {
-		return args.size();
-	}
-
-	@Override
-	public void insertArgument(int pos, String arg) {
-		args.add(pos, arg);
-	}
-
-	@Override
-	public String getArgument(int id) {
-		if (args == null || args.size() <= id){
-			throw new IllegalArgumentException("missing required argument");
-		}
-
-		return args.get(id);
-	}
-
-	@Override
-	public String getArgument(int id, String defaultValue) {
-		if (args == null || args.size() <= id){
-			return defaultValue;
-		}
-
-		return args.get(id);
 	}
 
 	@Override
 	public void respond(String response) {
 		event.respond(response);
-	}
-
-	@Override
-	public void respondSuccess() {
-		respond("The operation was successful.");
-	}
-
-	@Override
-	public String getMessage() {
-		return this.getArguments();
-	}
-
-	@Override
-	public  String getRawMessage() {
-		return event.getMessage();
 	}
 
 	@Override

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/ChannelMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/ChannelMessage.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.pircbotx.hooks.events.MessageEvent;
 
-class ChannelMessage extends BasicMessage {
+class ChannelMessage extends IRCMessage {
 	private final MessageEvent event;
 
 	public ChannelMessage(MessageEvent event, List<String> args) {

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/ChannelMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/ChannelMessage.java
@@ -16,30 +16,28 @@
  * You should have received a copy of the GNU General Public License along with
  * uc_pircbotx. If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.backends.irc;
 
 import java.util.List;
 
-import org.pircbotx.hooks.events.PrivateMessageEvent;
+import org.pircbotx.hooks.events.MessageEvent;
 
-class UserMessage extends BasicMessage {
-	private final PrivateMessageEvent event;
+class ChannelMessage extends BasicMessage {
+	private final MessageEvent event;
 
-	public UserMessage(PrivateMessageEvent event, List<String> args) {
+	public ChannelMessage(MessageEvent event, List<String> args) {
 		super(event, args);
 		this.event = event;
 	}
 
 	@Override
 	public void sendAction(String action) {
-		event.getUser().send().action(action);
+		event.getChannel().send().action(action);
 	}
 
 	@Override
 	public String getTargetName() {
-		return event.getUser().getNick();
+		return event.getChannel().getName();
 	}
-
-
 
 }

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/CommandListener.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/CommandListener.java
@@ -53,7 +53,7 @@ class CommandListener extends ListenerAdapter {
 			if (messageText.startsWith(prefix)) {
 				List<String> args = extractMessage(messageText.substring(1));
 
-				BasicMessage message = new ChannelMessage(event, args);
+				IRCMessage message = new ChannelMessage(event, args);
 				processor.invoke(message);
 			} else {
 				//check for someone trying to address the bot by name
@@ -61,7 +61,7 @@ class CommandListener extends ListenerAdapter {
 				Matcher matcher = pattern.matcher(messageText);
 				if (matcher.matches()) {
 					List<String> args = extractMessage(matcher.group(1));
-					BasicMessage message = new ChannelMessage(event, args);
+					IRCMessage message = new ChannelMessage(event, args);
 					processor.invoke(message);
 				}
 			}

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/CommandListener.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/CommandListener.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * uc_pircbotx. If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.backends.irc;
 
 import java.util.List;
 import java.util.regex.Matcher;

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/IRCFactory.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/IRCFactory.java
@@ -1,4 +1,4 @@
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.backends.irc;
 
 import javax.net.ssl.SSLSocketFactory;
 

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/IRCMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/IRCMessage.java
@@ -32,10 +32,10 @@ import uk.co.unitycoders.pircbotx.backends.AbstractMessage;
  * An abstract version of the Bot Message interface which deals with some of
  * the common features which we can deal with for the child classes.
  */
-abstract class BasicMessage extends AbstractMessage {
+abstract class IRCMessage extends AbstractMessage {
 	private final GenericMessageEvent event;
 
-	public BasicMessage(GenericMessageEvent message, List<String> args) {
+	public IRCMessage(GenericMessageEvent message, List<String> args) {
 		super(args);
 		this.event = message;
 	}

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/UserMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/UserMessage.java
@@ -16,28 +16,28 @@
  * You should have received a copy of the GNU General Public License along with
  * uc_pircbotx. If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.backends.irc;
 
 import java.util.List;
 
-import org.pircbotx.hooks.events.MessageEvent;
+import org.pircbotx.hooks.events.PrivateMessageEvent;
 
-class ChannelMessage extends BasicMessage {
-	private final MessageEvent event;
+class UserMessage extends BasicMessage {
+	private final PrivateMessageEvent event;
 
-	public ChannelMessage(MessageEvent event, List<String> args) {
+	public UserMessage(PrivateMessageEvent event, List<String> args) {
 		super(event, args);
 		this.event = event;
 	}
 
 	@Override
 	public void sendAction(String action) {
-		event.getChannel().send().action(action);
+		event.getUser().send().action(action);
 	}
 
 	@Override
 	public String getTargetName() {
-		return event.getChannel().getName();
+		return event.getUser().getNick();
 	}
 
 }

--- a/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/UserMessage.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/backends/irc/UserMessage.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 import org.pircbotx.hooks.events.PrivateMessageEvent;
 
-class UserMessage extends BasicMessage {
+class UserMessage extends IRCMessage {
 	private final PrivateMessageEvent event;
 
 	public UserMessage(PrivateMessageEvent event, List<String> args) {

--- a/src/main/java/uk/co/unitycoders/pircbotx/commands/IRCCommands.java
+++ b/src/main/java/uk/co/unitycoders/pircbotx/commands/IRCCommands.java
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU General Public License along with
  * uc_pircbotx. If not, see <http://www.gnu.org/licenses/>.
  */
-package uk.co.unitycoders.pircbotx.commandprocessor.irc;
+package uk.co.unitycoders.pircbotx.commands;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/src/main/resources/META-INF/services/uk.co.unitycoders.pircbotx.modules.Module
+++ b/src/main/resources/META-INF/services/uk.co.unitycoders.pircbotx.modules.Module
@@ -9,4 +9,4 @@ uk.co.unitycoders.pircbotx.commands.NickCommand
 uk.co.unitycoders.pircbotx.commands.KarmaCommand
 uk.co.unitycoders.pircbotx.commands.GamesCommand
 uk.co.unitycoders.pircbotx.commands.CompSciCommand
-uk.co.unitycoders.pircbotx.commandprocessor.irc.IRCCommands
+uk.co.unitycoders.pircbotx.commands.IRCCommands


### PR DESCRIPTION
This change allows the swapping out of IRC for a terminal/console based backend to test plugins without needing to connect the bot to IRC.

Its also a stepping stone to allow for XMPP based connections (although this requires abstracting out some of the protocol-specific stuff like the bot). I've left this out of the PR as at the moment this requires no API changes for plugins.